### PR TITLE
gd-front-page-posts-not-aligned

### DIFF
--- a/src/components/PostCard.astro
+++ b/src/components/PostCard.astro
@@ -12,38 +12,35 @@ const { title, publishedAt, description, slug } = Astro.props;
 ---
 
 <a
-  class="group flex max-w-sm cursor-pointer flex-col gap-2 rounded-md border border-neutral-700 p-4 transition-all duration-300 hover:-translate-y-2 hover:border-neutral-400"
+  class="grid grid-cols-2 group cursor-pointer rounded-md border border-neutral-700 p-4 transition-all duration-300 hover:-translate-y-2 hover:border-neutral-400"
   href={`/posts/${slug}`}
 >
-  <div
-    class="flex w-full flex-col justify-between gap-2 md:flex-row md:items-center"
+  <p class="title text-neutral-100">{title}</p>
+
+  <svg
+    width="18"
+    height="18"
+    viewBox="0 0 18 18"
+    fill="none"
+    class="justify-self-end arrow transition-all duration-300 group-hover:translate-x-1"
   >
-    <p class="text-neutral-100">{title}</p>
-    <div class="flex flex-row items-center gap-4">
-      <p>{formatDate(publishedAt)}</p>
+    <path
+      d="M5.25 12.75L12.75 5.25"
+      stroke="#999999"
+      stroke-linecap="round"
+      stroke-linejoin="round"></path>
+    <path
+      d="M5.25 5.25H12.75V12.75"
+      stroke="#999999"
+      stroke-linecap="round"
+      stroke-linejoin="round"></path>
+  </svg>
 
-      <svg
-        width="18"
-        height="18"
-        viewBox="0 0 18 18"
-        fill="none"
-        class="transition-all duration-300 group-hover:translate-x-1"
-      >
-        <path
-          d="M5.25 12.75L12.75 5.25"
-          stroke="#999999"
-          stroke-linecap="round"
-          stroke-linejoin="round"></path>
-        <path
-          d="M5.25 5.25H12.75V12.75"
-          stroke="#999999"
-          stroke-linecap="round"
-          stroke-linejoin="round"></path>
-      </svg>
-    </div>
-  </div>
+  <time datetime={publishedAt.toISOString()} class="col-span-2"
+    >{formatDate(publishedAt)}</time
+  >
 
-  <p class="truncate">
+  <p class="truncate col-span-2">
     {description}
   </p>
 </a>

--- a/src/components/PostsListing.astro
+++ b/src/components/PostsListing.astro
@@ -16,11 +16,13 @@ const posts = (await getCollection("posts")).sort(function (first, second) {
   </header>
   {posts.length === 0 && <p>Soon, stay connected 👀...</p>}
 
-  <section class="flex flex-col gap-4 md:flex-row md:flex-wrap">
+  <section
+    class="grid grid-cols-1 gap-4 md:grid-cols-2 md:flex-wrap justify-between"
+  >
     {
       posts.length !== 0 &&
         posts
-          .slice(0, 2)
+          .slice(0, 4)
           .map((post) => (
             <PostCard
               publishedAt={post.data.publishedAt}

--- a/src/components/PostsListing.astro
+++ b/src/components/PostsListing.astro
@@ -9,7 +9,7 @@ const posts = (await getCollection("posts")).sort(function (first, second) {
 });
 ---
 
-<article class="flex flex-col gap-8">
+<article class="flex flex-col gap-4 mb-6">
   <header class="flex w-full flex-row justify-between gap-2">
     <h3 class="text-lg text-neutral-100">Latest posts</h3>
     <Link href="/posts" label="See all posts" isUnderline target="_self" />

--- a/src/components/PostsListing.astro
+++ b/src/components/PostsListing.astro
@@ -9,8 +9,8 @@ const posts = (await getCollection("posts")).sort(function (first, second) {
 });
 ---
 
-<article class="flex flex-col gap-4 mb-6">
-  <header class="flex w-full flex-row justify-between gap-2">
+<article class="mb-6">
+  <header class="flex mb-4 w-full flex-row justify-between gap-2">
     <h3 class="text-lg text-neutral-100">Latest posts</h3>
     <Link href="/posts" label="See all posts" isUnderline target="_self" />
   </header>
@@ -20,17 +20,16 @@ const posts = (await getCollection("posts")).sort(function (first, second) {
     class="grid grid-cols-1 gap-4 md:grid-cols-2 md:flex-wrap justify-between"
   >
     {
-      posts.length !== 0 &&
-        posts
-          .slice(0, 4)
-          .map((post) => (
-            <PostCard
-              publishedAt={post.data.publishedAt}
-              title={post.data.title}
-              description={post.data.description}
-              slug={post.slug}
-            />
-          ))
+      posts
+        .slice(0, 4)
+        .map((post) => (
+          <PostCard
+            publishedAt={post.data.publishedAt}
+            title={post.data.title}
+            description={post.data.description}
+            slug={post.slug}
+          />
+        ))
     }
   </section>
 </article>

--- a/src/components/ProjectListing.astro
+++ b/src/components/ProjectListing.astro
@@ -5,21 +5,18 @@ import ProjectCard from "@/components/ProjectCard.astro";
 const projects = await getCollection("projects");
 ---
 
-<article class="flex flex-col gap-8">
-  <header class="flex w-full flex-row justify-between gap-2">
+<article class="mb-6">
+  <header class="mb-4">
     <h3 class="text-lg text-neutral-100">
       Selected projects ({projects.length})
     </h3>
   </header>
-  {
-    (
-      <pre>
-        <section class="flex flex-col gap-4">
-          {projects.map(({ data: project, slug }) => (
-            <ProjectCard slug={slug} {...project} />
-          ))}
-        </section>
-      </pre>
-    )
-  }
+
+  <section class="flex flex-col gap-4">
+    {
+      projects.map(({ data: project, slug }) => (
+        <ProjectCard slug={slug} {...project} />
+      ))
+    }
+  </section>
 </article>

--- a/src/layouts/Layout.astro
+++ b/src/layouts/Layout.astro
@@ -1,6 +1,7 @@
 ---
 import Header from "../components/Header.astro";
 import SEOTags from "@/components/seo/SEOTags.astro";
+import SocialLinks from "@/components/SocialLinks.astro";
 import type { HeadTags } from "@/utils/types/HeadTags";
 
 import "@fontsource/open-sans";
@@ -21,5 +22,7 @@ const headTags = Astro.props;
   >
     <Header />
     <slot />
-  </body>
+  </body><footer>
+    <SocialLinks />
+  </footer>
 </html>

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -3,7 +3,6 @@ import { Picture } from "astro:assets";
 
 import Layout from "@/layouts/Layout.astro";
 import SocialLinks from "@/components/SocialLinks.astro";
-import Link from "@/components/shared/Link.astro";
 import ProjectListing from "@/components/ProjectListing.astro";
 import PostsListing from "@/components/PostsListing.astro";
 
@@ -11,57 +10,41 @@ import { presentation } from "@/data/presentation";
 ---
 
 <Layout>
-  <main class="flex flex-col justify-between">
-    <article
-      class="flex flex-col gap-8 md:flex-row-reverse md:justify-between md:gap-12 pb-6"
-    >
-      {
-        presentation.profile && (
-          <div class="w-1/4 md:justify-end">
-            <Picture
-              src={presentation.profile}
-              class="rounded-full md:justify-end"
-              alt="Profile Image"
-              widths={[200, 400]}
-              formats={["webp", "avif"]}
-              loading="lazy"
-              width="200"
-              height="200"
-            />
-          </div>
-        )
-      }
+  <article
+    class="flex flex-col gap-8 md:flex-row-reverse md:justify-between md:gap-12 pb-6"
+  >
+    {
+      presentation.profile && (
+        <div class="w-1/4 md:justify-end">
+          <Picture
+            src={presentation.profile}
+            class="rounded-full md:justify-end"
+            alt="Profile Image"
+            widths={[200, 400]}
+            formats={["webp", "avif"]}
+            loading="lazy"
+            width="200"
+            height="200"
+          />
+        </div>
+      )
+    }
 
-      <div class="flex flex-col gap-8">
-        <h1 class="text-3xl text-neutral-100">
-          {presentation.title}
-        </h1>
+    <div class="flex flex-col gap-8">
+      <h1 class="text-3xl text-neutral-100">
+        {presentation.title}
+      </h1>
 
-        <h2
-          class="w-auto max-w-[60ch] leading-6"
-          set:html={presentation.description}
-        />
-
-        <SocialLinks />
-      </div>
-    </article>
-
-    <PostsListing />
-
-    <ProjectListing />
-
-    <article class="flex flex-col gap-8">
-      <header class="flex w-full flex-row justify-between gap-2">
-        <h3 class="text-lg text-neutral-100">Get in touch</h3>
-      </header>
-      <p>
-        Email me at <Link
-          href={`mailto:${presentation.mail}`}
-          label={presentation.mail}
-        /> or follow me via my social links.
-      </p>
+      <h2
+        class="w-auto max-w-[60ch] leading-6"
+        set:html={presentation.description}
+      />
 
       <SocialLinks />
-    </article>
-  </main>
+    </div>
+  </article>
+
+  <PostsListing />
+
+  <ProjectListing />
 </Layout>


### PR DESCRIPTION
This pull request addresses several styling and structural issues on the front page, specifically focusing on the alignment and presentation of posts. The changes made include:

- **Styling Fixes:** 
  - Adjusted the layout to display the latest 4 posts in a more visually appealing manner.
  - Simplified the card design using a grid layout for better organization.

- **Semantic Improvements:**
  - Flattened the HTML structure for improved readability and maintenance.
  - Organized elements within a grid to enhance the overall layout.
  - Utilized semantic HTML elements, including the `<time>` element, to improve accessibility and SEO.
  - Added machine-readable datetime attributes for better indexing by search engines.
  - Adjusted spacing to reduce the gap above the grid while increasing the space below for a balanced look.

- **Refactoring:**
  - Streamlined the layout to ensure social links are consistently displayed across all pages.
  - Removed unnecessary attributes and checks to clean up the codebase.
  - Added margins to improve spacing under the header and overall visual hierarchy.